### PR TITLE
Change missing `compileSdkVersion` on Android to 28.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+1
+
+* Set Android `compileSdkVersion` to 28 in order to prevent build errors with AndroidX.
+
 ## 0.4.0
 
 * **Breaking change**. Migrate from the deprecated original Android Support

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_mailer
 description: Share an email to device Email - Client supports multiple Attachments
-version: 0.4.0
+version: 0.4.0+1
 author: Tal Jaconson <tal1989@gmail.com>
 homepage:  https://github.com/taljacobson/flutter_mailer
 


### PR DESCRIPTION
This was causing build issues like missing resources and was an oversight in the previous PR.

An oversight on my part, sorry for that.