### PR TITLE
Simple androidx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+1
+
+* replace androidx appcompat with core dependency for simpler classpath
+
 ## 0.4.1
 
 * return platform error if no mail app available in ios

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.0'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'androidx.appcompat:appcompat:1.0.0-beta01'
+    api 'androidx.core:core:1.0.2'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.0'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 16 13:09:56 IDT 2018
+#Wed May 15 00:22:53 BST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,8 +4,8 @@ description: Demonstrates how to use the flutter_mailer plugin.
 dependencies:
   flutter:
     sdk: flutter
-  image_picker: ^0.5.0
-  path_provider: ^0.5.0
+  image_picker: ^0.6.0+3
+  path_provider: ^1.1.0
   flutter_mailer:
     path: ../
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_mailer
 description: Share an email to device Email - Client supports multiple Attachments
-version: 0.4.1
+version: 0.4.1+1
 author: Tal Jaconson <tal1989@gmail.com>
 homepage:  https://github.com/taljacobson/flutter_mailer
 


### PR DESCRIPTION
The plugin only requires androidx core classes & therefore should not include the appcompat dependency which carries a lot more classes and further dependencies.