### PR TITLE
Remove distinction between single and multiple attachments.

### DIFF
--- a/android/src/main/java/com/dataxad/fluttermailer/FlutterMailerPlugin.java
+++ b/android/src/main/java/com/dataxad/fluttermailer/FlutterMailerPlugin.java
@@ -132,11 +132,6 @@ public class FlutterMailerPlugin implements MethodCallHandler, PluginRegistry.Ac
                         .setType("message/rfc822")
                         .putExtra(Intent.EXTRA_STREAM, uris)
                         .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                if (attachments.size() == 1) {
-
-                    intent.setAction(Intent.ACTION_SEND)
-                            .putExtra(Intent.EXTRA_STREAM, uris.get(0));
-                }
             }
         }
 


### PR DESCRIPTION
When a user decides to use Google Drive instead of a mail client to open the intent, the subject becomes the file name. This is obviously incorrect because it removes the extension of the file. Removing these lines solves this problem. I'm not sure why they were there.