### PR TITLE
Added root-path to the mailer paths xml file

### DIFF
--- a/android/src/main/res/xml/flutter_mailer_paths.xml
+++ b/android/src/main/res/xml/flutter_mailer_paths.xml
@@ -2,4 +2,5 @@
 <paths>
     <cache-path name="cache_files" path="." />
     <external-path name="external_files" path="."/>
+	<root-path name="root" path="."/>
 </paths>


### PR DESCRIPTION
This allows the user to attach files from the application documents without having to copy them to the cache first.
It achieves this by providing the root folder of the application to the `FileProvider`.

Resolves issue #10 