### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.dataxad.flutter_mailer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <provider
             android:name="com.dataxad.flutter_mailer.FlutterMailerFileProvider"


### PR DESCRIPTION
Fixes

```
* What went wrong:
Execution failed for task ':flutter_mailer:processDebugManifest'.
> A failure occurred while executing com.android.build.gradle.tasks.ProcessLibraryManifest$ProcessLibWorkAction
   > Incorrect package="com.dataxad.flutter_mailer" found in source AndroidManifest.xml: /Users/daniel/.pub-cache/hosted/pub.dev/flutter_mailer-2.1.1/android/src/main/AndroidManifest.xml.
     Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
     Recommendation: remove package="com.dataxad.flutter_mailer" from the source AndroidManifest.xml: /Users/daniel/.pub-cache/hosted/pub.dev/flutter_mailer-2.1.1/android/src/main/AndroidManifest.xml.
```