### PR TITLE
Really fix AGP 8.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 2.1.2
+  [Android] Fix AGP 8.x namespace declaration
+
 ## 2.1.1
   [Android] set minSDKVersion back to 16
+
 ## 2.1.0
   [Android] republish 2.0.3 [issue #55](https://github.com/taljacobson/flutter_mailer/issues/47) do to increased minSdkVersion
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.android.library'
 android {
      // Conditional for compatibility with AGP <4.2. https://github.com/flutter/flutter/issues/125621
     if (project.android.hasProperty("namespace")) {
-        namespace 'icom.dataxad.flutter_mailer'
+        namespace 'com.dataxad.flutter_mailer'
     }
     compileSdkVersion 28
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_mailer
 description: Share an email to device Email - Client supports multiple Attachments
-version: 2.1.1
+version: 2.1.2
 homepage:  https://github.com/taljacobson/flutter_mailer
 
 dependencies:


### PR DESCRIPTION
This is a proper fix for AGP `8.x`.

Closes #56 

If you want to use this fix now, you can override the dependency like this - for the time being:

```yaml
dependency_overrides:
  flutter_mailer:
    git:
      url: https://github.com/ThexXTURBOXx/flutter_mailer.git
      ref: patch-1
```