### PR TITLE
fix: remove registerWith for android build issue on v2 plugin

### DIFF
--- a/android/src/main/java/com/dataxad/flutter_mailer/FlutterMailerPlugin.java
+++ b/android/src/main/java/com/dataxad/flutter_mailer/FlutterMailerPlugin.java
@@ -19,13 +19,6 @@ public class FlutterMailerPlugin implements FlutterPlugin, ActivityAware {
     private @Nullable
     ActivityPluginBinding activityBinding;
 
-    public static void registerWith(PluginRegistry.Registrar registrar) {
-        final FlutterMailerPlugin plugin = new FlutterMailerPlugin();
-        final MethodCallHandlerImpl methodCallHandler = new MethodCallHandlerImpl(registrar.context(), registrar.activity());
-        registrar.addActivityResultListener(methodCallHandler);
-        plugin.setupChannel(registrar.messenger(), methodCallHandler);
-    }
-
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {
         final MethodCallHandlerImpl methodCallHandler = new MethodCallHandlerImpl(binding.getApplicationContext(), null);


### PR DESCRIPTION
android build error when `flutter build app`:
```
public static void registerWith(PluginRegistry.Registrar registrar) {
                                                  ^
  symbol:   class Registrar
  location: interface PluginRegistry
```

This is from v2 plugin issue, we have to remove `registerWith` to build with v2